### PR TITLE
New counter functionalities

### DIFF
--- a/src/pymodaq_plugins_daqmx/daq_viewer_plugins/plugins_0D/daq_0Dviewer_DAQmx_PLcounter.py
+++ b/src/pymodaq_plugins_daqmx/daq_viewer_plugins/plugins_0D/daq_0Dviewer_DAQmx_PLcounter.py
@@ -18,21 +18,12 @@ class DAQ_0DViewer_DAQmx_PLcounter(DAQ_Viewer_base):
     params = comon_parameters+[
        {"title": "Counting channel:", "name": "counter_channel",
           "type": "list", "limits": DAQmx.get_NIDAQ_channels(source_type="Counter")},
-        {"title": "Source settings:", "name": "source_settings",
-           "type": "group", "visible": True, "children": [
-             {"title": "Enable?:", "name": "enable", "type": "bool",
-                "value": False, },
-             {"title": "Photon source:", "name": "photon_channel",
-                "type": "list", "limits": DAQmx.getTriggeringSources()},
-             {"title": "Edge type:", "name": "edge", "type": "list",
-                "limits": Edge.names(), "visible": False},
-             {"title": "Level:", "name": "level", "type": "float",
-                "value": 1., "visible": False}]
-         },
+        {"title": "Photon source:", "name": "photon_channel",
+         "type": "list", "limits": DAQmx.getTriggeringSources()},
         {"title": "Clock frequency (Hz):", "name": "clock_freq",
             "type": "float", "value": 100., "default": 100., "min": 1},
         {'title': 'Clock channel:', 'name': 'clock_channel', 'type': 'list',
-             'limits': DAQmx.get_NIDAQ_channels(source_type='Counter')},
+             'limits': DAQmx.get_NIDAQ_channels(source_type='Counter')}
         ]
 
     def ini_attributes(self):
@@ -108,40 +99,13 @@ class DAQ_0DViewer_DAQmx_PLcounter(DAQ_Viewer_base):
         #         update = False  # we are already live
         #     self.live = kwargs['live']
             
-        #if update:
+        # if update:
         self.update_tasks()
             
-        self.controller["clock"].stop() # to ensure that the clock is available
-        self.controller["clock"].task.CfgImplicitTiming(DAQmx_Val_FiniteSamps, 1000)
-
-        try:
-            timeout = 2
-            self.controller["clock"].start()
-            #self.controller["clock"].task.WaitUntilTaskDone(timeout*2)
-        except Exception as e:
-            print(e)
-            self.emit_status(ThreadCommand('Update_Status',
-                                               ['Cannot start the counter clock']))
-            return
-        
-        self.controller["counter"].task.CfgImplicitTiming(DAQmx_Val_ContSamps, 1000)
-        self.controller["counter"].task.SetReadRelativeTo(DAQmx_Val_CurrReadPos)
-        self.controller["counter"].task.SetReadOffset(0)
-        self.controller["counter"].task.SetReadOverWrite(DAQmx_Val_DoNotOverwriteUnreadSamps)
-        
-        try:
-            self.controller["counter"].start()
-        except Exception as e:
-            print(e)
-            self.emit_status(ThreadCommand('Update_Status',
-                                               ['Cannot start the PL counter']))
-                
-        print("ready to read")
         read_data = self.controller["counter"].readCounter(2, counting_time=self.counting_time,
                                                            read_function="")
         print(read_data)
-        data_pl = 1e-3*np.sum(read_data)/self.counting_time
-            
+        data_pl = 1e-3*read_data/self.counting_time
         self.data_grabed_signal.emit([DataFromPlugins(name='PL', data=[data_pl],
                                                       dim='Data0D', labels=['PL (kcts/s)'])])
 
@@ -153,42 +117,23 @@ class DAQ_0DViewer_DAQmx_PLcounter(DAQ_Viewer_base):
 
     def update_tasks(self):
         """Set up the counting tasks in the NI card."""
-        # Create channels
-        self.create_channels()
-        # configure tasks
-        self.configure_tasks()
-        # connect everything
-        self.connect_channels()
+        # Create channel
+        self.counter_channel = Counter(name=self.settings.child("counter_channel").value(),
+                                       source="Counter", edge=Edge.names()[0])
 
-    def create_channels(self):
-        """ Create the channels in the NI card to update the tasks."""
-        clock_freq = self.settings.child("clock_freq").value()
-        self.clock_channel = ClockCounter(clock_freq,
-                                          name=self.settings.child("clock_channel").value(),
-                                          source="Counter")
-        
-        self.counter_channel = SemiPeriodCounter(5e6,
-                                    name=self.settings.child("counter_channel").value(),
-                                    source="Counter")
-       
-    def configure_tasks(self):
-        """ Configure the tasks in the NI card, by calling the update functions of each controller."""
-        self.controller["clock"].update_task(channels=[self.clock_channel],
-                                             # do not configure clock yet, so Nsamples=1
-                                             clock_settings=ClockSettings(Nsamples=1),
-                                             trigger_settings=TriggerSettings())
         self.controller["counter"].update_task(channels=[self.counter_channel],
-                                               clock_settings=ClockSettings(Nsamples=1),
-                                               trigger_settings=TriggerSettings())
-        
-    def connect_channels(self):
-        """ Connect together the channels for synchronization."""
-        # connect the pulses from the clock to the counter
-        self.controller["counter"].task.SetCISemiPeriodTerm(self.counter_channel.name,
-                                                '/'+self.clock_channel.name + "InternalOutput")
-        # define the source of ticks for the counter 
-        self.controller["counter"].task.SetCICtrTimebaseSrc(self.counter_channel.name,
-                            self.settings.child("source_settings", "photon_channel").value())
+                                               clock_settings=ClockSettings(
+                                                   source=self.settings.child("clock_channel"),
+                                                   frequency=self.settings.child("clock_freq"),
+                                                   edge=Edge.names()[0],
+                                                   repetition=True,
+                                                   Nsamples=1),
+                                               trigger_settings=TriggerSettings(
+                                                   trig_source=self.settings.child("photon_channel"),
+                                                   enable=True,
+                                                   edge=Edge.names()[0],
+                                                   level=0.5)
+                                               )
         
         
 if __name__ == '__main__':

--- a/src/pymodaq_plugins_daqmx/daq_viewer_plugins/plugins_0D/daq_0Dviewer_DAQmx_PLcounter.py
+++ b/src/pymodaq_plugins_daqmx/daq_viewer_plugins/plugins_0D/daq_0Dviewer_DAQmx_PLcounter.py
@@ -1,0 +1,192 @@
+import numpy as np
+from pymodaq.utils.daq_utils import ThreadCommand
+from pymodaq.utils.data import DataFromPlugins
+from pymodaq.control_modules.viewer_utility_classes import DAQ_Viewer_base, comon_parameters, main
+from pymodaq.utils.parameter import Parameter
+
+from pymodaq_plugins_daqmx.hardware.national_instruments.daqmx import DAQmx, \
+    Edge, ClockSettings, ClockCounter, SemiPeriodCounter, TriggerSettings
+
+from PyDAQmx import DAQmx_Val_DoNotInvertPolarity, \
+     DAQmx_Val_ContSamps, DAQmx_Val_FiniteSamps, DAQmx_Val_CurrReadPos, \
+     DAQmx_Val_DoNotOverwriteUnreadSamps
+
+class DAQ_0DViewer_DAQmx_PLcounter(DAQ_Viewer_base):
+    """
+    Plugin for a 0D PL counter, based on a NI card.
+    """
+    params = comon_parameters+[
+       {"title": "Counting channel:", "name": "counter_channel",
+          "type": "list", "limits": DAQmx.get_NIDAQ_channels(source_type="Counter")},
+        {"title": "Source settings:", "name": "source_settings",
+           "type": "group", "visible": True, "children": [
+             {"title": "Enable?:", "name": "enable", "type": "bool",
+                "value": False, },
+             {"title": "Photon source:", "name": "photon_channel",
+                "type": "list", "limits": DAQmx.getTriggeringSources()},
+             {"title": "Edge type:", "name": "edge", "type": "list",
+                "limits": Edge.names(), "visible": False},
+             {"title": "Level:", "name": "level", "type": "float",
+                "value": 1., "visible": False}]
+         },
+        {"title": "Clock frequency (Hz):", "name": "clock_freq",
+            "type": "float", "value": 100., "default": 100., "min": 1},
+        {'title': 'Clock channel:', 'name': 'clock_channel', 'type': 'list',
+             'limits': DAQmx.get_NIDAQ_channels(source_type='Counter')},
+        ]
+
+    def ini_attributes(self):
+        self.controller = None
+        self.clock_channel = None
+        self.counter_channel = None
+        self.live = False  # True during a continuous grab
+        self.counting_time = 0.1
+
+    def commit_settings(self, param: Parameter):
+        """Apply the consequences of a change of value in the detector settings
+
+        Parameters
+        ----------
+        param: Parameter
+            A given parameter (within detector_settings) whose value has been changed by the user
+        """
+        if param.name() == "clock_freq":
+            self.counting_time = 1/param.value()
+        else:
+            self.stop()
+            self.update_tasks()
+       
+
+    def ini_detector(self, controller=None):
+        """Detector communication initialization
+
+        Parameters
+        ----------
+        controller: (object)
+            custom object of a PyMoDAQ plugin (Slave case). None if only one actuator/detector by controller
+            (Master case)
+
+        Returns
+        -------
+        info: str
+        initialized: bool
+            False if initialization failed otherwise True
+        """
+        self.controller = {"clock": DAQmx(), "counter": DAQmx()}
+        try:
+            self.update_tasks()
+            initialized = True
+            info = "NI card based PL counter"
+        except Exception as e:
+            print(e)
+            initialized = False
+            info = "Error"
+            
+        self.data_grabed_signal_temp.emit([DataFromPlugins(name='PL',data=[np.array([0])],
+                                                           dim='Data0D', labels=['PL (kcts/s)'])])
+        return info, initialized
+    
+    def close(self):
+        """Terminate the communication protocol"""
+        self.controller["clock"].close()
+        self.controller["counter"].close()
+        
+    def grab_data(self, Naverage=1, **kwargs):
+        """Start a grab from the detector
+
+        Parameters
+        ----------
+        Naverage: int
+            Number of hardware averaging not relevant here.
+        kwargs: dict
+            others optionals arguments
+        """
+        update = True  # to decide if we do the initial set up or not
+
+        if 'live' in kwargs:
+            if kwargs['live'] == self.live and self.live:
+                update = False  # we are already live
+            self.live = kwargs['live']
+            
+        if update:
+            self.update_tasks()
+            
+        self.controller["clock"].task.stop() # to ensure that the clock is available
+        self.controller["clock"].task.CfgImplicitTiming(DAQmx_Val_FiniteSamps, 1000)
+
+        self.controller["counter"].task.CfgImplicitTiming(DAQmx_Val_ContSamps, 2))
+        self.controller["counter"].task.DAQmxSetReadRelativeTo(DAQmx_Val_CurrReadPos)
+        self.controller["counter"].task.DAQmxSetReadOffset(0)
+        self.controller["counter"].task.DAQmxSetReadOverWrite(DAQmx_Val_DoNotOverwriteUnreadSamps)
+
+        try:
+            timeout = 10
+            self.controller["clock"].start()
+            self.controller["clock"].task.WaitUntilTaskDone(timeout*2)
+        except Exception as e:
+            print(e)
+            self.emit_status(ThreadCommand('Update_Status',
+                                               ['Cannot start the counter clock']))
+            return
+        
+        try:
+            self.controller["counter"].start()
+        except Exception as e:
+            print(e)
+            self.emit_status(ThreadCommand('Update_Status',
+                                               ['Cannot start the PL counter']))
+
+        read_data = self.controller["counter"].readCounter(2, counting_time=self.counting_time)
+        data_pl = 1e-3*np.sum(read_data)/self.counting_time
+            
+        self.data_grabed_signal.emit([DataFromPlugins(name='PL', data=[data_pl],
+                                                      dim='Data0D', labels=['PL (kcts/s)'])])
+
+    def stop(self):
+        """Stop the current grab hardware wise if necessary"""
+        self.close()
+        self.emit_status(ThreadCommand('Update_Status', ['Acquisition stopped.']))
+        return ''
+
+    def update_tasks(self):
+        """Set up the counting tasks in the NI card."""
+        # Create channels
+        self.create_channels()
+        # configure tasks
+        self.configure_tasks()
+        # connect everything
+        self.connect_channels()
+
+    def create_channels(self):
+        """ Create the channels in the NI card to update the tasks."""
+        clock_freq = self.settings.child("clock_freq").value()
+        self.clock_channel = ClockCounter(clock_freq,
+                                          name=self.settings.child("clock_channel").value(),
+                                          source="Counter")
+        
+        self.counter_channel = SemiPeriodCounter(5e6,
+                                    name=self.settings.child("counter_channel").value(),
+                                    source="Counter")
+       
+    def configure_tasks(self):
+        """ Configure the tasks in the NI card, by calling the update functions of each controller."""
+        self.controller["clock"].update_task(channels=[self.clock_channel],
+                                             # do not configure clock yet, so Nsamples=1
+                                             clock_settings=ClockSettings(Nsamples=1),
+                                             trigger_settings=TriggerSettings())
+        self.controller["counter"].update_task(channels=[self.counter_channel],
+                                               clock_settings=ClockSettings(Nsamples=1),
+                                               trigger_settings=TriggerSettings())
+        
+    def connect_channels(self):
+        """ Connect together the channels for synchronization."""
+        # connect the pulses from the clock to the counter
+        self.controller["counter"].task.SetCISemiPeriodTerm(self.counter_channel.name,
+                                                '/'+self.clock_channel.name + "InternalOutput")
+        # define the source of ticks for the counter 
+        self.controller["counter"].task.SetCICtrTimebaseSrc(self.counter_channel.name,
+                            self.settings.child("source_settings", "photon_channel").value())
+        
+        
+if __name__ == '__main__':
+    main(__file__)

--- a/src/pymodaq_plugins_daqmx/daq_viewer_plugins/plugins_0D/daq_0Dviewer_DAQmx_PLcounter.py
+++ b/src/pymodaq_plugins_daqmx/daq_viewer_plugins/plugins_0D/daq_0Dviewer_DAQmx_PLcounter.py
@@ -5,11 +5,11 @@ from pymodaq.control_modules.viewer_utility_classes import DAQ_Viewer_base, como
 from pymodaq.utils.parameter import Parameter
 
 from pymodaq_plugins_daqmx.hardware.national_instruments.daqmx import DAQmx, \
-    Edge, ClockSettings, ClockCounter, SemiPeriodCounter, TriggerSettings
+    Edge, ClockSettings, Counter,  TriggerSettings
 
-from PyDAQmx import DAQmx_Val_DoNotInvertPolarity, \
-     DAQmx_Val_ContSamps, DAQmx_Val_FiniteSamps, DAQmx_Val_CurrReadPos, \
-     DAQmx_Val_DoNotOverwriteUnreadSamps
+# from PyDAQmx import DAQmx_Val_DoNotInvertPolarity, \
+#      DAQmx_Val_ContSamps, DAQmx_Val_FiniteSamps, DAQmx_Val_CurrReadPos, \
+#      DAQmx_Val_DoNotOverwriteUnreadSamps
 
 class DAQ_0DViewer_DAQmx_PLcounter(DAQ_Viewer_base):
     """
@@ -102,8 +102,7 @@ class DAQ_0DViewer_DAQmx_PLcounter(DAQ_Viewer_base):
         # if update:
         self.update_tasks()
             
-        read_data = self.controller["counter"].readCounter(2, counting_time=self.counting_time,
-                                                           read_function="")
+        read_data = self.controller["counter"].readCounter(1, counting_time=self.counting_time)
         print(read_data)
         data_pl = 1e-3*read_data/self.counting_time
         self.data_grabed_signal.emit([DataFromPlugins(name='PL', data=[data_pl],
@@ -123,13 +122,13 @@ class DAQ_0DViewer_DAQmx_PLcounter(DAQ_Viewer_base):
 
         self.controller["counter"].update_task(channels=[self.counter_channel],
                                                clock_settings=ClockSettings(
-                                                   source=self.settings.child("clock_channel"),
-                                                   frequency=self.settings.child("clock_freq"),
+                                                   source=self.settings.child("clock_channel").value(),
+                                                   frequency=self.settings.child("clock_freq").value(),
                                                    edge=Edge.names()[0],
                                                    repetition=True,
                                                    Nsamples=1),
                                                trigger_settings=TriggerSettings(
-                                                   trig_source=self.settings.child("photon_channel"),
+                                                   trig_source=self.settings.child("photon_channel").value(),
                                                    enable=True,
                                                    edge=Edge.names()[0],
                                                    level=0.5)

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daq_NIDAQmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daq_NIDAQmx.py
@@ -294,6 +294,7 @@ class DAQ_NIDAQmx_base(DAQmx):
         self.channels = None
         self.clock_settings = None
         self.trigger_settings = None
+        self.live = False
         self.refresh_hardware()
 
 

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -192,7 +192,7 @@ class AOChannel(AChannel):
 
 
 class Counter(Channel):
-    def __init__(self, edge=Edge.names()[0], , **kwargs):
+    def __init__(self, edge=Edge.names()[0], **kwargs):
         assert edge in Edge.names()    
         super().__init__(**kwargs)
         self.edge = edge

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -192,19 +192,27 @@ class AOChannel(AChannel):
 
 
 class Counter(Channel):
-    def __init__(self, edge=Edge.names()[0], counter_type="Edge counter", **kwargs):
-        if counter_type == "Edge counter":
-            assert edge in Edge.names()    
+    def __init__(self, edge=Edge.names()[0], , **kwargs):
+        assert edge in Edge.names()    
         super().__init__(**kwargs)
         self.edge = edge
-        # counter_type options are Edge Counter, Clock Output and SemiPeriod Input
-        self.counter_type = counter_type
-        if kwargs.get("clock_frequency"):
-            self.clock_frequency = kwargs["clock_frequency"]
-        if kwargs.get("clock_frequency"):
-            self.value_max = kwargs["value_max"]
+        self.counter_type == "Edge Counter"
 
+        
+class ClockCounter(Counter):
+    def __init__(self, clock_frequency=10, **kwargs):
+        super().__init__(**kwargs)
+        self.clock_frequency = clock_frequency
+        self.counter_type == "Clock Output"
 
+        
+class SemiPeriodCounter(Counter):
+    def __init__(self, value_max=5e6, **kwargs):
+        super().__init__(**kwargs)
+        self.value_max = value_max
+        self.counter_type == "SemiPeriod Input"
+
+        
 class DigitalChannel(Channel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -452,7 +452,7 @@ class DAQmx:
                                                                      Edge[channel.edge].value, 0,
                                                                      PyDAQmx.DAQmx_Val_CountUp)
                     elif channel.counter_type == "Clock Output":
-                        err_code = self._task.CreateCOPulseChanFreq(channel.name, "",
+                        err_code = self._task.CreateCOPulseChanFreq("/"+channel.name, "",
                                                                     # units, Hertz in our case
                                                                     PyDAQmx.DAQmx_Val_Hz,
                                                                     # idle state
@@ -466,7 +466,7 @@ class DAQmx:
                                                                     # equal to count_interval
                                                                     0.5)
                     elif channel.counter_type == "SemiPeriod Input":
-                        err_code = self._task.CreateCISemiPeriodChan(channel.name, "", 0, # expected min
+                        err_code = self._task.CreateCISemiPeriodChan("/"+channel.name, "", 0, # expected min
                                                                      channel.value_max, # expected max
                                                                      PyDAQmx.DAQmx_Val_Ticks, "")
                         

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -452,7 +452,7 @@ class DAQmx:
                                                                      Edge[channel.edge].value, 0,
                                                                      PyDAQmx.DAQmx_Val_CountUp)
                     elif channel.counter_type == "Clock Output":
-                        err_code = self._task.CreateCOPulseChanFreq("/"+channel.name, "",
+                        err_code = self._task.CreateCOPulseChanFreq(channel.name, "",
                                                                     # units, Hertz in our case
                                                                     PyDAQmx.DAQmx_Val_Hz,
                                                                     # idle state
@@ -466,7 +466,7 @@ class DAQmx:
                                                                     # equal to count_interval
                                                                     0.5)
                     elif channel.counter_type == "SemiPeriod Input":
-                        err_code = self._task.CreateCISemiPeriodChan("/"+channel.name, "", 0, # expected min
+                        err_code = self._task.CreateCISemiPeriodChan(channel.name, "", 0, # expected min
                                                                      channel.value_max, # expected max
                                                                      PyDAQmx.DAQmx_Val_Ticks, "")
                         

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -200,14 +200,14 @@ class Counter(Channel):
 
         
 class ClockCounter(Counter):
-    def __init__(self, clock_frequency=10, **kwargs):
+    def __init__(self, clock_frequency, **kwargs):
         super().__init__(**kwargs)
         self.clock_frequency = clock_frequency
         self.counter_type == "Clock Output"
 
         
 class SemiPeriodCounter(Counter):
-    def __init__(self, value_max=5e6, **kwargs):
+    def __init__(self, value_max, **kwargs):
         super().__init__(**kwargs)
         self.value_max = value_max
         self.counter_type == "SemiPeriod Input"

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -675,9 +675,14 @@ class DAQmx:
 
         data_counter = np.zeros(Nchannels, dtype='uint32')
         read = PyDAQmx.int32()
-        self._task.ReadCounterU32Ex(PyDAQmx.DAQmx_Val_Auto, 2*counting_time, PyDAQmx.DAQmx_Val_GroupByChannel,
-                                    data_counter,
-                                    Nchannels, PyDAQmx.byref(read), None)
+        try:
+            self._task.ReadCounterU32Ex(PyDAQmx.DAQmx_Val_Auto, 2*counting_time,
+                                        PyDAQmx.DAQmx_Val_GroupByChannel,
+                                        data_counter,
+                                        Nchannels, PyDAQmx.byref(read), None)
+        except:
+            self._task.ReadCounterU32(PyDAQmx.DAQmx_Val_Auto, 2*counting_time,
+                                        data_counter, Nchannels, PyDAQmx.byref(read), None)
         self._task.StopTask()
 
         if read.value == Nchannels:

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -570,11 +570,14 @@ class DAQmx:
             # else:
             #     pass
 
-            ##configure the triggering
+            ##configure the triggering, except for counters
             if not trigger_settings.enable:
-                err = self._task.DisableStartTrig()
-                if err != 0:
-                    raise IOError(self.DAQmxGetErrorString(err))
+                if channel.source == 'Counter':
+                    pass
+                else:
+                    err = self._task.DisableStartTrig()
+                    if err != 0:
+                        raise IOError(self.DAQmxGetErrorString(err))
             else:
                 if 'PF' in trigger_settings.trig_source:
                     self._task.CfgDigEdgeStartTrig(trigger_settings.trig_source, Edge[trigger_settings.edge].value)

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -424,7 +424,7 @@ class DAQmx:
             for channel in channels:
                 if channel.source == 'Analog_Input': #analog input
                     if channel.analog_type == "Voltage":
-                        err_code = self._task.CreateAIVoltageChan(channel.name, "",
+                        err_code = self._task.CreateAIVoltageChan(channel.name, "analog voltage task",
                                      DAQ_termination[channel.termination].value,
                                      channel.value_min,
                                      channel.value_max,
@@ -452,7 +452,7 @@ class DAQmx:
                                                                      Edge[channel.edge].value, 0,
                                                                      PyDAQmx.DAQmx_Val_CountUp)
                     elif channel.counter_type == "Clock Output":
-                        err_code = self._task.CreateCOPulseChanFreq(channel.name, "",
+                        err_code = self._task.CreateCOPulseChanFreq(channel.name, "clock task",
                                                                     # units, Hertz in our case
                                                                     PyDAQmx.DAQmx_Val_Hz,
                                                                     # idle state
@@ -466,7 +466,8 @@ class DAQmx:
                                                                     # equal to count_interval
                                                                     0.5)
                     elif channel.counter_type == "SemiPeriod Input":
-                        err_code = self._task.CreateCISemiPeriodChan(channel.name, "", 0, # expected min
+                        err_code = self._task.CreateCISemiPeriodChan(channel.name, "counter task",
+                                                                     0, # expected min
                                                                      channel.value_max, # expected max
                                                                      PyDAQmx.DAQmx_Val_Ticks, "")
                         

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -674,18 +674,21 @@ class DAQmx:
         else:
             raise IOError(f'Insufficient number of samples have been read:{read.value}/{N}')
 
-    def readCounter(self, Nchannels, counting_time=10.):
+    def readCounter(self, Nchannels, counting_time=10., read_function="Ex"):
 
         data_counter = np.zeros(Nchannels, dtype='uint32')
         read = PyDAQmx.int32()
-        try:
+        if read_function == "Ex":
+            print("Ex")
             self._task.ReadCounterU32Ex(PyDAQmx.DAQmx_Val_Auto, 2*counting_time,
                                         PyDAQmx.DAQmx_Val_GroupByChannel,
                                         data_counter,
                                         Nchannels, PyDAQmx.byref(read), None)
-        except:
+        else:
+            print("Pas Ex")
             self._task.ReadCounterU32(PyDAQmx.DAQmx_Val_Auto, 2*counting_time,
                                         data_counter, Nchannels, PyDAQmx.byref(read), None)
+            
         self._task.StopTask()
 
         if read.value == Nchannels:

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -580,7 +580,8 @@ class DAQmx:
                         raise IOError(self.DAQmxGetErrorString(err))
             else:
                 if 'PF' in trigger_settings.trig_source:
-                    self._task.CfgDigEdgeStartTrig(trigger_settings.trig_source, Edge[trigger_settings.edge].value)
+                    self._task.CfgDigEdgeStartTrig(trigger_settings.trig_source,
+                                                   Edge[trigger_settings.edge].value)
                 elif 'ai' in trigger_settings.trig_source:
                     self._task.CfgAnlgEdgeStartTrig(trigger_settings.trig_source,
                                                     Edge[trigger_settings.edge].value,
@@ -679,13 +680,11 @@ class DAQmx:
         data_counter = np.zeros(Nchannels, dtype='uint32')
         read = PyDAQmx.int32()
         if read_function == "Ex":
-            print("Ex")
             self._task.ReadCounterU32Ex(PyDAQmx.DAQmx_Val_Auto, 2*counting_time,
                                         PyDAQmx.DAQmx_Val_GroupByChannel,
                                         data_counter,
                                         Nchannels, PyDAQmx.byref(read), None)
         else:
-            print("Pas Ex")
             self._task.ReadCounterU32(PyDAQmx.DAQmx_Val_Auto, 2*counting_time,
                                         data_counter, Nchannels, PyDAQmx.byref(read), None)
             

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -196,21 +196,21 @@ class Counter(Channel):
         assert edge in Edge.names()    
         super().__init__(**kwargs)
         self.edge = edge
-        self.counter_type == "Edge Counter"
+        self.counter_type = "Edge Counter"
 
         
 class ClockCounter(Counter):
     def __init__(self, clock_frequency, **kwargs):
         super().__init__(**kwargs)
         self.clock_frequency = clock_frequency
-        self.counter_type == "Clock Output"
+        self.counter_type = "Clock Output"
 
         
 class SemiPeriodCounter(Counter):
     def __init__(self, value_max, **kwargs):
         super().__init__(**kwargs)
         self.value_max = value_max
-        self.counter_type == "SemiPeriod Input"
+        self.counter_type = "SemiPeriod Input"
 
         
 class DigitalChannel(Channel):

--- a/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
+++ b/src/pymodaq_plugins_daqmx/hardware/national_instruments/daqmx.py
@@ -193,7 +193,8 @@ class AOChannel(AChannel):
 
 class Counter(Channel):
     def __init__(self, edge=Edge.names()[0], counter_type="Edge counter", **kwargs):
-        assert edge in Edge.names()
+        if counter_type == "Edge counter":
+            assert edge in Edge.names()    
         super().__init__(**kwargs)
         self.edge = edge
         # counter_type options are Edge Counter, Clock Output and SemiPeriod Input


### PR DESCRIPTION
Hello!
I added new counter types in the daqmx.py file, besides the regular Edge counter:
- A ClockCounter, which is use to output a clock signal.
- A SemiPeriodCounter, which allows gathering the data from both the up and the down time of the duty cycle. I took inspiration from Qudi there, and I used it for my ODMR module.

I also created a 0D viewer corresponding to a photon counter.